### PR TITLE
shim window.location.replaceHash and use it in all places

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require replacehash
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets

--- a/app/assets/javascripts/mirrorbrain-fix.js
+++ b/app/assets/javascripts/mirrorbrain-fix.js
@@ -50,15 +50,8 @@ var MirrorbrainFix = {
             $.post("/public/recordings/count", {event_id: $video.data('id'), src: mediaElement.src});
           }, false);
           mediaElement.addEventListener('pause', function() {
-            var hash = '#video&t='+Math.round(mediaElement.currentTime);;
-            if(window.history && window.history.replaceState) {
-              // set new hash without adding an entry into the browser history
-              window.history.replaceState(null, "", hash);
-            }
-            else {
-              // classic fallback
-              window.location.hash = hash;
-            }
+            var hash = '#video&t='+Math.round(mediaElement.currentTime);
+            window.location.replaceHash(hash);
           }, false);
         }
       });

--- a/app/assets/javascripts/replacehash.js
+++ b/app/assets/javascripts/replacehash.js
@@ -1,0 +1,17 @@
+// Closure to protect local variable "var hash"
+(function(ns) {
+
+  ns.replaceHash = function(newhash) {
+    if ((''+newhash).charAt(0) !== '#')
+      newhash = '#' + newhash;
+
+    if(window.history && window.history.replaceState) {
+      history.replaceState({}, '', newhash);
+    }
+    else
+    {
+      window.location.hash = hash;
+    }
+  }
+
+})(window.location);

--- a/app/assets/javascripts/replacehash.js
+++ b/app/assets/javascripts/replacehash.js
@@ -6,7 +6,7 @@
       newhash = '#' + newhash;
 
     if(window.history && window.history.replaceState) {
-      history.replaceState({}, '', newhash);
+      history.replaceState({url: window.location.href}, '', newhash);
     }
     else
     {

--- a/app/views/frontend/events/show.html.haml
+++ b/app/views/frontend/events/show.html.haml
@@ -84,14 +84,7 @@
 
   :javascript
     function setDefaultHash() {
-      var hash = '#video';
-      if(window.history && window.history.replaceState) {
-        // set new hash without adding an entry into the browser history
-        window.history.replaceState(null, "", hash);
-      } else {
-        // classic fallback
-        window.location.hash = hash;
-      }
+      window.location.replaceHash('#video');
     }
 
     // activate tab via hash and default to video
@@ -112,7 +105,7 @@
     // change hash on tab change
     $('.nav-tabs a').on('shown.bs.tab', function (e) {
       var hash = e.target.hash || e.target.dataset.target;
-      window.location.hash = hash;
+      window.location.replaceHash(hash);
     });
 
     // adjust tabs when hash changes


### PR DESCRIPTION
ensuring that the history state is never null fixes the turbolinks errors.
fixes #36
