### PR TITLE
Player: fullscreen feature to the right

### DIFF
--- a/app/assets/javascripts/mirrorbrain-fix.js
+++ b/app/assets/javascripts/mirrorbrain-fix.js
@@ -39,7 +39,7 @@ var MirrorbrainFix = {
       $('video').mediaelementplayer({
         usePluginFullScreen: true,
         enableAutosize: true,
-        features: ['playpause','progress','current','duration','tracks','volume','fullscreen', 'speed', 'sourcechooser'],
+        features: ['playpause','progress','current','duration','tracks','volume', 'speed', 'sourcechooser', 'fullscreen'],
         success: function (mediaElement) {
           mediaElement.addEventListener('canplay', function () {
             if(stamp) {


### PR DESCRIPTION
since all web-videoplayers i know have the fullscreen button on the lower right corner, do so here, too. Since speed and sourcechooser are pretty wide, the fullscreen button was shifted pretty far away from the corner.