### PR TITLE
Feature/sorting cleanup

### DIFF
--- a/app/controllers/frontend/conferences_controller.rb
+++ b/app/controllers/frontend/conferences_controller.rb
@@ -3,7 +3,7 @@ module Frontend
     SORT_PARAM = {
       'name' => 'title',
       'duration' => 'duration',
-      'date' => 'release_date desc'
+      'date' => 'date desc, release_date desc'
     }.freeze
 
     before_action :check_sort_param, only: %w(show)
@@ -46,7 +46,7 @@ module Frontend
 
     def sort_param
       return SORT_PARAM[@sorting] if @sorting
-      'title'
+      'date desc, release_date desc'
     end
 
     def check_sort_param

--- a/lib/frontend/folder_tree.rb
+++ b/lib/frontend/folder_tree.rb
@@ -66,7 +66,7 @@ module Frontend
 
     def sort_folders(folders)
       sorted = folders.select { |folder| not folder.conference? }.sort { |a, b| a.name <=> b.name }
-      sorted += (folders - sorted).sort { |a, b| b.conference.updated_at <=> a.conference.updated_at }
+      sorted += (folders - sorted).sort { |a, b| b.name <=> a.name }
       sorted
     end
 


### PR DESCRIPTION
fixes #71 
changing the sorting of the conferences may result in not-so-expected sorting (see #12)


![screencapture-localhost-3000-b-conferences-1461413213092](https://cloud.githubusercontent.com/assets/142237/14761305/b5b481ee-095c-11e6-97dc-429508440e14.png)

![screencapture-localhost-3000-b-congress-1461413205088](https://cloud.githubusercontent.com/assets/142237/14761304/b5b452a0-095c-11e6-8cf3-786828c166c1.png)
