### PR TITLE
use similar styled thumbs in the search results

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -134,13 +134,10 @@ ready = function() {
 					jQuery.each(res.hits.hits, function(idx, hit) {
 						var
 							quality = hit._score * 100 / res.hits.max_score,
-							logourl = hit._source.conference.logo;
+							image = hit._source.event.thumb_url;
 
-						if(logourl.match(/\.(png|jpg|jpeg|gif)$/)) {
-							logourl = logourl.substr(0, logourl.lastIndexOf('.')) + '.png';
-						}
-						else {
-							logourl = 'https://static.media.ccc.de/media/unknown.png';
+						if(!image) {
+							image = 'https://static.media.ccc.de/media/unknown.png';
 						}
 
 
@@ -161,9 +158,9 @@ ready = function() {
 							.find('h3 .t')
 								.text(hit._source.event.title)
 							.end()
-							.find('img.conference-logo')
-								.attr('alt', hit._source.conference.title)
-								.attr('src', logourl)
+							.find('img.image')
+								.attr('alt', hit._source.event.title)
+								.attr('src', image)
 							.end()
 							.find('a.conference-url')
 								.attr('href', hit._source.event.frontend_link)

--- a/app/assets/stylesheets/frontend/styles.scss
+++ b/app/assets/stylesheets/frontend/styles.scss
@@ -492,13 +492,13 @@ a.inverted {
     h3 .number::after {
       content: '.';
     }
-    .conference-logo {
+    .image {
       float: left;
-      width: 100px;
-      height: auto;
+      width: 160px;
+      height: 120px;
     }
     .caption {
-      margin-left: 100px;
+      margin-left: 160px;
     }
     
     .metadata {

--- a/app/views/frontend/shared/_search.haml
+++ b/app/views/frontend/shared/_search.haml
@@ -32,7 +32,7 @@
       %li.template
         .event-preview
           %a.conference-url{href: '#event.url'}
-            %img.conference-logo{src: '#event.conference.logo_url', alt: '#event.conference.title'}
+            %img.image{src: '#event.conference.logo_url', alt: '#event.conference.title'}
           .caption
             %ul.metadata
               %li.recording_length


### PR DESCRIPTION
as we do in the recordings-list. fixes #73 
![screencapture-localhost-3000-search-1461415016878](https://cloud.githubusercontent.com/assets/142237/14761425/a8dd0798-0961-11e6-88f7-e364ec430c70.png)
